### PR TITLE
Switch to new 'daily' Netex feed export

### DIFF
--- a/.otp-version
+++ b/.otp-version
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
 #
 # SPDX-License-Identifier: CC0-1.0
-export OTP_IMAGE="opentripplanner/opentripplanner:2.7.0_2025-02-21T08-35"
+export OTP_IMAGE="opentripplanner/opentripplanner:2.8.0_2025-03-21T10-43"

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -18,7 +18,8 @@ SOUTH_TYROL_PBF=data/south-tyrol.osm.pbf
 ELEVATION_URL=https://leonard.io/srtm/srtm_39_03.zip
 ELEVATION_ZIP=data/srtm_39_03.zip
 # transit data
-TRANSIT_NETEX_URL="https://rapuser:rappass@web01.sta.bz.it/netex/api/v4/downloadVersion?level=99&agencyCode=IT-ITH1"
+today=$(date +"%Y%m%d")
+TRANSIT_NETEX_URL="ftp://ftp.sta.bz.it/netex/2025/plan/EU_profil/daily/NX-PI_01_it_apb_LINE_apb__${today}.xml.zip"
 TRANSIT_NETEX_XML=data/sta-netex.xml
 TRANSIT_NETEX_GZ=${TRANSIT_NETEX_XML}.gz
 TRANSIT_NETEX_ZIP=${TRANSIT_NETEX_XML}.zip
@@ -62,8 +63,9 @@ fi
 
 rm -f ${TRANSIT_NETEX_ZIP}
 echo "Downloading NeTEx transit data from ${TRANSIT_NETEX_URL}"
-${CURL} "${TRANSIT_NETEX_URL}" -o ${TRANSIT_NETEX_GZ}
-gunzip --force ${TRANSIT_NETEX_GZ}
+${CURL} "${TRANSIT_NETEX_URL}" -o ${TRANSIT_NETEX_ZIP}
+unzip -o ${TRANSIT_NETEX_ZIP}
+mv NX-PI_01_it_apb_LINE_apb__*.xml ${TRANSIT_NETEX_XML}
 
 # Configuration
 

--- a/infrastructure/docker/otp/Dockerfile
+++ b/infrastructure/docker/otp/Dockerfile
@@ -1,5 +1,5 @@
 # Simon, do you know how we could use the value from .otp-version here?
-FROM opentripplanner/opentripplanner:2.7.0_2025-02-21T08-35
+FROM opentripplanner/opentripplanner:2.8.0_2025-03-21T10-43
 
 WORKDIR /var/otp
 


### PR DESCRIPTION
This switches the to the daily exportet NeTEx feed which contains a lot less data and (hopefully) only a single version of a line. The hope is that real-time matching will be improved.

In my preliminary tests I could already see the match rate jump from ~20% to ~%45.

cc @clezag @rcavaliere 