### PR TITLE
Update OTP image to make car rental work

### DIFF
--- a/.otp-version
+++ b/.otp-version
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
 #
 # SPDX-License-Identifier: CC0-1.0
-export OTP_IMAGE="opentripplanner/opentripplanner:2.8.0_2025-06-03T13-08"
+export OTP_IMAGE="lehrenfried/opentripplanner:car-rental-spaces"

--- a/infrastructure/docker/otp/Dockerfile
+++ b/infrastructure/docker/otp/Dockerfile
@@ -1,5 +1,5 @@
 # Simon, do you know how we could use the value from .otp-version here?
-FROM opentripplanner/opentripplanner:2.8.0_2025-06-03T13-08
+FROM lehrenfried/opentripplanner:car-rental-spaces
 
 WORKDIR /var/otp
 

--- a/router-config.json
+++ b/router-config.json
@@ -108,13 +108,11 @@
       "sourceType" : "gbfs",
       "url" : "https://carsharing.otp.opendatahub.testingmachine.eu/noi/gbfs.json"
     },
-    // we can re-enable this updater when https://github.com/opentripplanner/OpenTripPlanner/pull/6363
-    // is merged
-    /*{
+    {
       "type": "stop-time-updater",
       "url": "https://amarillo.otp.opendatahub.testingmachine.eu/gtfs/amarillo.altoadige.gtfsrt.pbf",
       "feedId": "amarillo"
-    },*/
+    },
     {
       "type": "vehicle-parking",
       "feedId": "parking",


### PR DESCRIPTION
This updates the OTP version to an temporary one that is build from this: https://github.com/opentripplanner/OpenTripPlanner/pull/6738

Once that is merged, we can revert to the upstream image.