### PR TITLE
Use newest version of x2gbfs, update URL

### DIFF
--- a/infrastructure/docker/carsharing/Dockerfile
+++ b/infrastructure/docker/carsharing/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/mobidata-bw/x2gbfs:2024-04-02T16-37
+# until https://github.com/mobidata-bw/x2gbfs/pull/259 is merged we use an image from Leonard's repo
+# afterwards we go back to upstream
+FROM ghcr.io/leonardehrenfried/x2gbfs:2025-07-07T11-20
 
 ARG CARSHARING_BASEURL=https://carsharing.otp.opendatahub.testingmachine.eu
 

--- a/router-config.json
+++ b/router-config.json
@@ -106,7 +106,7 @@
     {
       "type" : "vehicle-rental",
       "sourceType" : "gbfs",
-      "url" : "https://carsharing.otp.opendatahub.testingmachine.eu/noi/gbfs.json"
+      "url" : "https://carsharing.otp.opendatahub.testingmachine.eu/opendatahub/gbfs.json"
     },
     {
       "type": "stop-time-updater",


### PR DESCRIPTION
Updates the x2gbfs version to use https://github.com/mobidata-bw/x2gbfs/pull/259.

This should get real time information for car rental back.

Relates to #254